### PR TITLE
Add show.py

### DIFF
--- a/src/bplot/__init__.py
+++ b/src/bplot/__init__.py
@@ -1,3 +1,4 @@
+from bplot.show import show
 from bplot.autocorrelation import autocorrelation
 from bplot.box import box, box_h
 from bplot.colors import color, tab_color, old_color, CatColors

--- a/src/bplot/show.py
+++ b/src/bplot/show.py
@@ -1,23 +1,18 @@
 import matplotlib.pyplot as plt
 
-def show(*data):
+def show(*args, **kws):
   """Show a window with the given plot data. Blocks until window is closed.
 
   Parameters
   ----------
-  *data : indexable objects
-      An object with labelled data. (Axes, Line2D, Line2D list, etc...)
+  *args : pyplot args
+  **kws : pyplot kw
 
   Examples
   --------
-    The returned values from most bplot functions can be plotted.
+  Plot a line.
 
-        >>> bplot.show(bplot.line(x, y))
-
-    Plot multiple lines at once.
-
-        >>> bplot.show(bplot.line(x1, y1), bplot.line(x2, y2))
+        >>> bplot.line(x, y)
+        >>> bplot.show()
   """
-  for d in data:
-    plt.plot(data=d)
-  plt.show()
+  plt.show(*args, **kws)

--- a/src/bplot/show.py
+++ b/src/bplot/show.py
@@ -1,0 +1,23 @@
+import matplotlib.pyplot as plt
+
+def show(*data):
+  """Show a window with the given plot data. Blocks until window is closed.
+
+  Parameters
+  ----------
+  *data : indexable objects
+      An object with labelled data. (Axes, Line2D, Line2D list, etc...)
+
+  Examples
+  --------
+    The returned values from most bplot functions can be plotted.
+
+        >>> bplot.show(bplot.line(x, y))
+
+    Plot multiple lines at once.
+
+        >>> bplot.show(bplot.line(x1, y1), bplot.line(x2, y2))
+  """
+  for d in data:
+    plt.plot(data=d)
+  plt.show()


### PR DESCRIPTION
Allows for showing plot data outside of Jupyter Notebooks using
matplotlib's `show` function. In most cases this should just work
without additional setup.

I've tested this with Python3.7.4 on Debian Stretch, and Windows 10. I do not have a Mac to test on, but matplotlib docs suggest it should work.

In my case, I built Python3.7 from source, so I had to install
python3-tk then re-build from source, in order to get tkinter installed
as a proper matplotlib backend. (Debian)

My current format requires matplotlib>=3.1.0, which matches requirements.txt.